### PR TITLE
Baby berta training

### DIFF
--- a/src/conf/config.yaml
+++ b/src/conf/config.yaml
@@ -1,3 +1,9 @@
+paths:
+  data: 'data/babylm_10M'
+  big_data: 'data/babylm_100M'
+  dev_data: 'data/babylm_dev'
+  test_data: 'data/babylm_test'
+
 data_params:
   sample_with_replacement: False  # this must be False if corpus order is to be preserved during training
   training_order: 'original'  # original or shuffled, use this alongside consecutive_masking=True
@@ -15,6 +21,7 @@ data_params:
   tokenizer: 'phueb/BabyBERTa-1'  # larger than 8k slightly reduces performance
   add_prefix_space: True  # better if True, whether to treat first token like any other token (False in GPT-2)
   max_input_length: 128  # unacceptable performance if lower than ~32
+  corpora: ['aochildes']
 
 training_params:
   batch_size: 16
@@ -31,4 +38,4 @@ model_params:
   num_attention_heads: 8
   intermediate_size: 1024
   initializer_range: 0.02  # stdev of trunc normal for initializing all weights
-  layer_norm_eps: 1e-5  # 1e-5 default in fairseq (and slightly better performance), 1e-12 default in hgugingface,
+  layer_norm_eps: 1e-5  # 1e-5 default in fairseq (and slightly better performance), 1e-12 default in hgugingface, 

--- a/src/conf/config.yaml
+++ b/src/conf/config.yaml
@@ -1,0 +1,34 @@
+data_params:
+  sample_with_replacement: False  # this must be False if corpus order is to be preserved during training
+  training_order: 'original'  # original or shuffled, use this alongside consecutive_masking=True
+  consecutive_masking: False  # better dev pp and grammatical accuracy when false
+  num_sentences_per_input: 1  # if too large -> may exceed CUDA memory, 1 is best for good number-agreement
+  include_punctuation: True
+  allow_truncated_sentences: False
+  num_mask_patterns: 10  # 10 is better than fewer
+  mask_pattern_size: 2  # used only if probabilistic_masking = False
+  probabilistic_masking: True
+  mask_probability: 0.15  # used only if probabilistic_masking = true
+  leave_unmasked_prob_start: 0.0  # better performance if no unmasking
+  leave_unmasked_prob: 0.0  # better performance if no unmasking
+  random_token_prob: 0.1
+  tokenizer: 'phueb/BabyBERTa-1'  # larger than 8k slightly reduces performance
+  add_prefix_space: True  # better if True, whether to treat first token like any other token (False in GPT-2)
+  max_input_length: 128  # unacceptable performance if lower than ~32
+
+training_params:
+  batch_size: 16
+  lr: 1e-4  # 1e-4 is used in fairseq (and performs better here), and 1e-3 is default in huggingface
+  num_epochs: 1  # use 1 epoch to use dynamic masking
+  num_warmup_steps: 24_000  # 24K used in Roberta-base
+  weight_decay: 0.0
+  seed: 42 # randomly chosen by me (hem52)
+
+model_params:
+  load_from_checkpoint: 'none'
+  hidden_size: 256
+  num_layers: 8
+  num_attention_heads: 8
+  intermediate_size: 1024
+  initializer_range: 0.02  # stdev of trunc normal for initializing all weights
+  layer_norm_eps: 1e-5  # 1e-5 default in fairseq (and slightly better performance), 1e-12 default in hgugingface,

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,54 @@
+"""Defines the set of hyperparameters to be specified in the config file.
+Followed from the BabyBERTa repo."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+
+@dataclass
+class DataParams:
+    # data
+    sample_with_replacement: bool
+    consecutive_masking: bool
+    training_order: str
+    num_sentences_per_input: int
+    include_punctuation: bool
+    allow_truncated_sentences: bool
+    num_mask_patterns: int
+    mask_pattern_size: int
+    probabilistic_masking: bool
+    mask_probability: float
+    leave_unmasked_prob_start: float
+    leave_unmasked_prob: float
+    random_token_prob: float
+    tokenizer: str
+    add_prefix_space: bool
+    max_input_length: int
+
+@dataclass
+class TrainingParams:
+    # training
+    batch_size: int
+    lr: float
+    num_epochs: int
+    num_warmup_steps: int
+    weight_decay: float
+
+@dataclass
+class ModelParams:
+    # model
+    load_from_checkpoint: str
+    num_layers: int
+    hidden_size: int
+    num_attention_heads: int
+    intermediate_size: int
+    initializer_range: float
+    layer_norm_eps: float
+
+
+@dataclass
+class BabyBERTaConfig:
+    data_params: DataParams
+    training_params: TrainingParams
+    model_params: ModelParams

--- a/src/config.py
+++ b/src/config.py
@@ -2,9 +2,16 @@
 Followed from the BabyBERTa repo."""
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, List
 
 
+@dataclass
+class Paths:
+    # paths
+    data: str
+    big_data: str
+    dev_data: str
+    test_data: str
 
 @dataclass
 class DataParams:
@@ -25,6 +32,7 @@ class DataParams:
     tokenizer: str
     add_prefix_space: bool
     max_input_length: int
+    corpora: List[str]
 
 @dataclass
 class TrainingParams:
@@ -34,6 +42,7 @@ class TrainingParams:
     num_epochs: int
     num_warmup_steps: int
     weight_decay: float
+    seed: int
 
 @dataclass
 class ModelParams:
@@ -49,6 +58,7 @@ class ModelParams:
 
 @dataclass
 class BabyBERTaConfig:
+    paths: Paths
     data_params: DataParams
     training_params: TrainingParams
     model_params: ModelParams

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,76 @@
+"""Train a RoBERTa model on the BabyLM dataset."""
+
+import logging
+import argparse as ap
+
+from transformers.models.roberta import RobertaConfig, RobertaForMaskedLM, RobertaTokenizerFast
+from transformers import Trainer, TrainingArguments, set_seed
+from config import BabyBERTaConfig
+
+import hydra
+from hydra.core.config_store import ConfigStore
+
+cs = ConfigStore.instance()
+cs.store(name="config", node=BabyBERTaConfig)
+
+@hydra.main(config_path="conf", config_name="config")
+def main(cfg: BabyBERTaConfig):
+
+    # Set seed
+    set_seed(cfg.training_params.seed)
+
+    # Set up logging
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    # Load tokenizer
+    logger.info("Loading tokenizer")
+    tokenizer = RobertaTokenizerFast.from_pretrained(cfg.data_params.tokenizer,
+                                                    add_prefix_space=cfg.data_params.add_prefix_space)
+
+
+    
+    # Load model
+    logger.info("Initialising Roberta from scratch")
+    model = RobertaForMaskedLM(cfg.model_params)
+
+    # TODO: add a section to config for paths for output dir, logging dir, etc.
+    # Set up training arguments
+    training_args = TrainingArguments(
+        output_dir='.',
+        overwrite_output_dir=False,
+        do_train=True,
+        do_eval=False,
+        do_predict=False,
+        per_device_train_batch_size=cfg.training_params.batch_size,
+        learning_rate=cfg.training_params.lr,
+        max_steps=160_000,
+        warmup_steps=cfg.trainin_params.num_warmup_steps,
+        seed=cfg.training_params.seed,
+        save_steps=40_000,
+    )
+
+    # Set up trainer
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=cfg.data_params.train_dataset,
+        eval_dataset=cfg.data_params.eval_dataset,
+        tokenizer=tokenizer,
+        compute_metrics=cfg.data_params.compute_metrics,
+    )
+
+    # Train model
+    trainer.train()
+    trainer.save_model()
+
+    
+    
+
+
+
+if __name__ == "__main__":
+    ap.add_argument("--output_dir", type=str, default="output")
+    ap.add_argument("--logging_dir", type=str, default="logs")
+
+    main()

--- a/src/train.py
+++ b/src/train.py
@@ -1,14 +1,18 @@
 """Train a RoBERTa model on the BabyLM dataset."""
 
 import logging
-import argparse as ap
+import argparse
+import os
 
 from transformers.models.roberta import RobertaConfig, RobertaForMaskedLM, RobertaTokenizerFast
-from transformers import Trainer, TrainingArguments, set_seed
+from transformers import Trainer, TrainingArguments, set_seed, DataCollatorForLanguageModeling
+from datasets import load_dataset
 from config import BabyBERTaConfig
 
 import hydra
 from hydra.core.config_store import ConfigStore
+
+from pathlib import Path
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=BabyBERTaConfig)
@@ -25,16 +29,55 @@ def main(cfg: BabyBERTaConfig):
 
     # Load tokenizer
     logger.info("Loading tokenizer")
+    # the babyBERTa repo uses 
     tokenizer = RobertaTokenizerFast.from_pretrained(cfg.data_params.tokenizer,
                                                     add_prefix_space=cfg.data_params.add_prefix_space)
-
 
     
     # Load model
     logger.info("Initialising Roberta from scratch")
-    model = RobertaForMaskedLM(cfg.model_params)
+    config = RobertaConfig(vocab_size = tokenizer.vocab_size,
+                            hidden_size = cfg.model_params.hidden_size,
+                            num_hidden_layers = cfg.model_params.num_layers,
+                            num_attention_heads = cfg.model_params.num_attention_heads,
+                            intermediate_size = cfg.model_params.intermediate_size,
+                            initializer_range = cfg.model_params.initializer_range,
+                            layer_norm_eps = cfg.model_params.layer_norm_eps
+                            )
 
-    # TODO: add a section to config for paths for output dir, logging dir, etc.
+
+    model = RobertaForMaskedLM(config)
+
+    # load data
+    logger.info("Loading data")
+    # NOTE: hydra.job.chdir must be set to False for this to work
+    data_paths = [os.path.join(cfg.paths.data, corpus+'.train') for corpus in cfg.data_params.corpora]
+    dataset = load_dataset('text', data_files={'train': data_paths})
+
+    # Preprocess data
+    # TODO: more extensive preprocessing, remove punctuation, etc.
+    logger.info("Preprocessing data")
+    def tokenize_function(examples):
+        return tokenizer(examples['text'], 
+                            padding=True, 
+                            truncation=True, 
+                            max_length=cfg.data_params.max_input_length,
+                            return_special_tokens_mask=True
+                            )
+
+    tokenized_dataset = dataset.map(tokenize_function, 
+                            batched=True, 
+                            num_proc=4, 
+                            remove_columns=['text'],
+                            load_from_cache_file=False)
+
+    
+    train_dataset = tokenized_dataset['train']
+
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, 
+                                                    mlm=True, 
+                                                    mlm_probability=cfg.data_params.mask_probability)
+
     # Set up training arguments
     training_args = TrainingArguments(
         output_dir='.',
@@ -45,7 +88,7 @@ def main(cfg: BabyBERTaConfig):
         per_device_train_batch_size=cfg.training_params.batch_size,
         learning_rate=cfg.training_params.lr,
         max_steps=160_000,
-        warmup_steps=cfg.trainin_params.num_warmup_steps,
+        warmup_steps=cfg.training_params.num_warmup_steps,
         seed=cfg.training_params.seed,
         save_steps=40_000,
     )
@@ -54,10 +97,10 @@ def main(cfg: BabyBERTaConfig):
     trainer = Trainer(
         model=model,
         args=training_args,
-        train_dataset=cfg.data_params.train_dataset,
-        eval_dataset=cfg.data_params.eval_dataset,
+        train_dataset=train_dataset,
+        eval_dataset=None,
         tokenizer=tokenizer,
-        compute_metrics=cfg.data_params.compute_metrics,
+        data_collator=data_collator,
     )
 
     # Train model
@@ -65,11 +108,13 @@ def main(cfg: BabyBERTaConfig):
     trainer.save_model()
 
     
-    
-
 
 
 if __name__ == "__main__":
+    # TODO: add a section to config for paths for output dir, logging dir, etc.
+    # these don't need to be specified with every run with argparse
+    # only pass the args we want to override with hydra?
+    ap = argparse.ArgumentParser()
     ap.add_argument("--output_dir", type=str, default="output")
     ap.add_argument("--logging_dir", type=str, default="logs")
 


### PR DESCRIPTION
Adding a script to train a babyBERTa model from scratch.
Notes:
- training script adapted from huggingface and babyBERTa repos
- uses the same model and training params as the original babyBERTa model trained on AO-CHILDES 
- all params are documented in a config.yaml file and used in the main script with hydra functionality
- dataloading can handle any combination of corpora (I currently just use the aochildes subset as proof of working pipeline)
- no evaluation (ppl on dev or otherwise) in place yet
- also no preprocessing (removal of punctuation, etc.)
- it's using the default babyBerta tokenizer, it will be easy to switch it out with one of our own through the config specification

N.B. hydra changes the working directory to its custom output directory before running the file, so to load data properly, it currently has to be run as `python train.py hydra.job.chdir=False`. I would welcome a more elegant solution if anyone has one. 