### PR TITLE
Updating scripts work multi-gpu and single-gpu training

### DIFF
--- a/scripts/launch_interactive.sh
+++ b/scripts/launch_interactive.sh
@@ -1,4 +1,5 @@
 echo "Requesting ${1:-1} GPUs for interactive session"
 echo "Billing: ${2:-BUTTERY-SL2-GPU} -- If you are not a member of this project, please change this to your project"
 sintr --qos=INTR -A ${2:-BUTTERY-SL2-GPU} --gres=gpu:${1:-1} -t 1:0:0  -p ampere -N 1
-
+module purge 
+module load rhel8/default-amp

--- a/scripts/launch_slurm.wilkes3
+++ b/scripts/launch_slurm.wilkes3
@@ -97,4 +97,4 @@ srun torchrun \
 --rdzv_id $RANDOM \
 --rdzv_backend c10d \
 --rdzv_endpoint $head_node_ip:29500 \
-train.py
+train.py $@


### PR DESCRIPTION
updating scripts so that 
* 1 - interaction sessions loads correct OS (Red HAT Linux 8 distro) -- otherwise there's an issue with the SSH lib that doesn't let us use git-lfs 
* 2- slurm script uses CL args (i.e. experiment.name =...)