### PR TITLE
Data Curriculum Bug Fix 

### DIFF
--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -95,15 +95,14 @@ class _CustomSingleProcessDataLoaderIter(_BaseDataLoaderIter):
         Returns next data from this iterator.
         """
 
-        if not isinstance(
+        if isinstance(
             self.loader.sampler,
             (CurriculumSampler, DistributedCurriculumSampler),
         ):
-            return super()._next_data()
-
-        assert (
-            self.loader.sampler.global_stepnum == self.loader.global_stepnum
-        ), "The global stepnum of the sampler and the dataloader are not the same"
+            assert (
+                self.loader.sampler.global_stepnum
+                == self.loader.global_stepnum
+            ), "The global stepnum of the sampler and the dataloader are not the same"
 
         index = self._next_index()  # may raise StopIteration
 

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -47,7 +47,12 @@ class CurriculumLearningCallback(TrainerCallback):
         self, args, state, control, train_dataloader, **kwargs
     ) -> None:
         train_dataloader.global_stepnum += 1
-        train_dataloader.sampler.global_stepnum += 1
+
+        if isinstance(
+            train_dataloader.sampler,
+            (CurriculumSampler, DistributedCurriculumSampler),
+        ):
+            train_dataloader.sampler.global_stepnum += 1
 
 
 class CustomTrainer(Trainer):


### PR DESCRIPTION
Enables removing data_curriculum to use a random data sampler as a default when no curriculum specified