### PR TITLE
Vocabulary curriculum

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -6,7 +6,7 @@ defaults:
   - model: babyberta_mlm
   - objective_curriculum: base_mlm
   - data_curriculum: linear_perplexity
-  - tokenizer_curriculum: linear_token_ids
+  - vocabulary_curriculum: linear_token_ids
 
 dataset: 
   name: 'CamBabyTrainers/BabyLM'

--- a/conf/vocabulary_curriculum/linear_token_ids.yaml
+++ b/conf/vocabulary_curriculum/linear_token_ids.yaml
@@ -1,6 +1,6 @@
-vocabulary_scorer_name: "token_ids"
+vocabulary_curriculum_name: "token_ids"
 pacing_fn_name: "linear"
 pacing_fn_kwargs: {"start_percent": 0.1,
                   "end_percent": 0.8,
-                  "starting_difficulty": 0.0,
+                  "starting_difficulty": 0.2,
                   "max_difficulty": 1.0}

--- a/src/config.py
+++ b/src/config.py
@@ -138,13 +138,14 @@ class DataCurriculumParams(DictConfig):
 
     pacing_fn_kwargs: PacingFunctionParams
 
-## Tokenizer curriculum parameters ##
-@dataclass
-class TokenizerCurriculumParams(DictConfig):
-    # data-driven curriculum learning parameters
 
-    # the function used to determine which tokens to map to <unk> (aka token_ids, etc.)
-    vocabulary_scorer_name: str
+## Vocabulary curriculum parameters ##
+@dataclass
+class VocabularyCurriculumParams(DictConfig):
+    # vocabulary curriculum learning parameters
+
+    # the curriculum used to determine which tokens to map to <unk> (aka token_ids, part of speech etc.)
+    vocabulary_curriculum_name: str
 
     # one of ['linear', 'quad', 'root', 'step', 'exp', 'log'] or None, meaning no pacing
     pacing_fn_name: str
@@ -165,4 +166,4 @@ class BabyLMConfig(DictConfig):
     trainer: TrainerParams
     objective_curriculum: ObjectiveCurriculumParams
     data_curriculum: Optional[DataCurriculumParams] = None
-    tokenizer_curriculum: Optional[TokenizerCurriculumParams] = None
+    vocabulary_curriculum: Optional[VocabularyCurriculumParams] = None

--- a/src/vocabulary_map/__init__.py
+++ b/src/vocabulary_map/__init__.py
@@ -1,0 +1,37 @@
+""" This module uses the difficulty scorer registry to get a difficulty scorer"""
+
+from typing import Callable
+
+from transformers import PreTrainedTokenizerFast
+
+# typing imports
+from .base_map import BaseVocabularyMap
+from .registry import VOCABULARY_MAP_REGISTRY
+
+
+def get_vocabulary_map(
+    vocabulary_curriculum_name: str,
+    tokenizer: PreTrainedTokenizerFast,
+    pacing_fn: Callable[[int], float],
+) -> BaseVocabularyMap:
+    """
+    Returns a vocabulary map based on the name.
+
+    Args:
+        * tokenizer_curriculum_name (str): The name of the difficulty scorer
+        * tokenizer (PreTrainedTokenizerFast): The tokenizer object
+        * pacing_fn (Callable[[int], float]): The pacing function to use for the vocabulary map
+    Returns:
+        * BaseVocabularyMap: A difficulty scorer
+    """
+
+    if vocabulary_curriculum_name in VOCABULARY_MAP_REGISTRY:
+        vocabulary_map = VOCABULARY_MAP_REGISTRY[vocabulary_curriculum_name](
+            tokenizer, pacing_fn
+        )
+        return vocabulary_map
+
+    else:
+        raise ValueError(
+            f"Difficulty Scorer {vocabulary_curriculum_name} not supported."
+        )

--- a/src/vocabulary_map/base_map.py
+++ b/src/vocabulary_map/base_map.py
@@ -1,0 +1,39 @@
+""" Implements an abstract base class for restricting the vocabulary during training. """
+
+from abc import ABCMeta, abstractmethod
+from typing import Callable
+
+from torch import Tensor
+from transformers import PreTrainedTokenizerFast
+
+
+class BaseVocabularyMap(metaclass=ABCMeta):
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerFast,
+        pacing_fn: Callable[[int], float],
+    ):
+        """
+        Args:
+            * tokenizer (PreTrainedTokenizer): The tokenizer used for preprocessing the data
+            * pacing_fn (Callable[[int], float]): A function that takes in the global step number
+        """
+        self.tokenizer = tokenizer
+        self.pacing_fn = pacing_fn
+
+    @abstractmethod
+    def map_tokens(
+        self,
+        ids: Tensor,
+        global_stepnum: int,
+    ) -> Tensor:
+        """
+        Map a tensor of token ids to a tensor of token ids with difficult tokens mapped to <unk>.
+
+        Args:
+            * ids (Tensor): A Tensor containing token ids
+            * global_stepnum (int): The global step number of the training loop
+        Returns:
+            * mapped_ids (Tensor): A Tensor containing the token ids with difficult tokens mapped to <unk>
+        """
+        raise NotImplementedError

--- a/src/vocabulary_map/registry.py
+++ b/src/vocabulary_map/registry.py
@@ -1,0 +1,15 @@
+from typing import Mapping, Type, TypeVar
+
+from .base_map import BaseVocabularyMap
+
+T = TypeVar("T", bound=BaseVocabularyMap)
+
+VOCABULARY_MAP_REGISTRY: Mapping[str, Type[BaseVocabularyMap]] = {}
+
+
+def register_vocabulary_map(name: str):
+    def _register(cls: Type[T]) -> Type[T]:
+        VOCABULARY_MAP_REGISTRY[name] = cls
+        return cls
+
+    return _register

--- a/src/vocabulary_map/token_id_map.py
+++ b/src/vocabulary_map/token_id_map.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Callable
+
+from torch import Tensor
+from transformers import PreTrainedTokenizerFast
+
+from .base_map import BaseVocabularyMap
+from .registry import register_vocabulary_map
+
+logger = logging.getLogger("VocabularyMap")
+
+
+@register_vocabulary_map("token_ids")
+class TokenIDVocabularyMap(BaseVocabularyMap):
+    """Uses the value of the token ID itself to determine whether to map the token to <unk>.
+
+    This works because the tokenizer assigns the earliest merges the lowest token IDs, so higher token IDs
+    correspond to less frequent (so presumably more difficult) tokens.
+    """
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerFast,
+        pacing_fn: Callable[[int], float],
+    ):
+        """
+        Args:
+            * tokenizer (PreTrainedTokenizer): The tokenizer used for preprocessing the data
+        """
+
+        super().__init__(tokenizer, pacing_fn)
+        self.unk_token_id = (
+            tokenizer.unk_token_id
+            if tokenizer.unk_token_id is not None
+            else tokenizer.all_special_ids[-1]
+        )
+        self.vocab_size = tokenizer.vocab_size
+
+    def map_tokens(
+        self,
+        ids: Tensor,
+        global_stepnum: int,
+    ) -> Tensor:
+        """
+        Map a tensor of token ids to a tensor of token ids with difficult tokens mapped to <unk>.
+
+        Args:
+            * ids (Tensor): A Tensor containing token ids
+            * global_stepnum (int): The global step number of the training loop
+        Returns:
+            * mapped_ids (Tensor): A Tensor containing the token ids with difficult tokens mapped to <unk>
+        """
+
+        max_id = self.pacing_fn(global_stepnum) * self.vocab_size
+        return ids.masked_fill(ids > max_id, self.unk_token_id)


### PR DESCRIPTION
I'm calling this feature "vocabulary curriculum" but do let me know if you come up with something better. 

The current functionality is pretty basic, adding a "vocabulary map" object to the data curriculum loader which will map certain token IDs to the UNK during training. The default behaviour is to limit the vocabulary simply based on the token ID itself, using a linear pacing function. At the start of training, all tokens above a certain value will be mapped to <UNK> and this will linearly change during training.