### PR TITLE
Add new var (offline_run) that takes over some functionality from dry_run

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -17,8 +17,11 @@ class ExperimentParams(DictConfig):
     # analogous to 'project' in wandb
     group: str = MISSING
 
-    # whether to run the experiment only locally
+    # whether to run a minimal version of the experiment
     dry_run: bool = False
+
+    # whether to run the experiment only offline
+    offline_run: bool = False
 
 
 @dataclass

--- a/src/data_curriculum/difficulty_scorer/perplexity.py
+++ b/src/data_curriculum/difficulty_scorer/perplexity.py
@@ -259,7 +259,7 @@ class SelfPerplexityScorer(PerplexityBaseClass):
                 # since we pass the data through the model
 
                 dataset = prepare_dataset_for_ppl_inference(
-                    self._trainer, dataset
+                    self.trainer, dataset
                 )
 
                 data_cl_logger.info(


### PR DESCRIPTION
dry_run used to mean try to run a small version of the model and training process and also don't log to wandb and HF. We can now separate those two - we might still want to test a small version of the model and see whether it logs correctly.