### PR TITLE
Make perplexity batch size depend on tokenizer vocab size

### DIFF
--- a/src/data_curriculum/difficulty_scorer/perplexity.py
+++ b/src/data_curriculum/difficulty_scorer/perplexity.py
@@ -284,7 +284,7 @@ class SelfPerplexityScorer(PerplexityBaseClass):
 
                     inference_dataloader = DataLoader(
                         dataset,  # type: ignore
-                        batch_size=32,
+                        batch_size=4 if self.tokenizer.vocab_size > 10_000 else 32,
                         shuffle=False,
                         collate_fn=base_collate_fn,
                         sampler=sampler,

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -490,7 +490,7 @@ class CustomTrainer(Trainer):
 
             inference_dataloader = DataLoader(
                 eval_subset,  # type: ignore
-                batch_size=32,  # TODO: Depends on model size (roberta baseline runs out of mem)
+                batch_size=4 if self.tokenizer.vocab_size > 10_000 else 32, 
                 shuffle=False,
                 collate_fn=base_collate_fn,
                 pin_memory=True,


### PR DESCRIPTION
really simply heuristic - if batch size is more than 10k set bs to 4; otherwise 32 -- 4 works for vocab size of 50k, and doesn't hurt overall performance all that much (it's not 8 times slower than bs of 32)  