### PR TITLE
Setting Batch Size of PPL Dataloader to just be 4

### DIFF
--- a/src/data_curriculum/difficulty_scorer/perplexity.py
+++ b/src/data_curriculum/difficulty_scorer/perplexity.py
@@ -284,7 +284,7 @@ class SelfPerplexityScorer(PerplexityBaseClass):
 
                     inference_dataloader = DataLoader(
                         dataset,  # type: ignore
-                        batch_size=4 if self.tokenizer.vocab_size > 10_000 else 32,
+                        batch_size=4,
                         shuffle=False,
                         collate_fn=base_collate_fn,
                         sampler=sampler,

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -490,7 +490,7 @@ class CustomTrainer(Trainer):
 
             inference_dataloader = DataLoader(
                 eval_subset,  # type: ignore
-                batch_size=4 if self.tokenizer.vocab_size > 10_000 else 32, 
+                batch_size=4,
                 shuffle=False,
                 collate_fn=base_collate_fn,
                 pin_memory=True,


### PR DESCRIPTION
Getting tired of making mistakes in the PPL dataloader by sometimes having 4 sometimes 32; performance is similar-ish since the GPU utilization is high either way. 