### PR TITLE
Fix perplexity calculation

### DIFF
--- a/src/utils/data.py
+++ b/src/utils/data.py
@@ -172,12 +172,22 @@ class DatasetPreprocessor(object):
                     [filename] * len(tokenized_inputs["input_ids"])
                 )
             else:
-                truncated_length = (((len(tokenized_inputs["input_ids"]) - 1) // self.max_input_length) + 1) * self.max_input_length  # type: ignore
+                # Split into multiple examples if the input is too long
                 for i in range(
                     0,
-                    truncated_length,
+                    len(tokenized_inputs["input_ids"]),
                     self.max_input_length,
                 ):
+                    # Check if the final example would contain only special tokens and if so, don't include it
+                    if (
+                        sum(
+                            tokenized_inputs["special_tokens_mask"][
+                                i : i + self.max_input_length
+                            ]
+                        )
+                        == self.max_input_length
+                    ):
+                        break
                     batch["input_ids"].append(
                         tokenized_inputs["input_ids"][i : i + self.max_input_length]  # type: ignore
                     )

--- a/src/utils/inference.py
+++ b/src/utils/inference.py
@@ -119,6 +119,10 @@ def compute_trainer_perplexity(
 
     # Now we divide by the number of non-masked tokens in each batch to get avg loss
     non_masked_tokens = torch.sum(special_tokens_mask == 0, dim=-1).squeeze()
+
+    # Avoiding division by zero
+    non_masked_tokens[non_masked_tokens == 0] = 1
+
     mean_loss = summed_loss / non_masked_tokens
 
     # batch perplexity is a vector of length batch_size


### PR DESCRIPTION
The issue was some examples would be full of special tokens, leading to a division by 0 error. We fix this by:
1. Avoiding ever dividing by 0
2. Avoiding examples being full of special tokens