### PR TITLE
Update evaluator script to load in best model seen

### DIFF
--- a/scripts/launch_evaluator.wilkes3
+++ b/scripts/launch_evaluator.wilkes3
@@ -23,7 +23,7 @@
 #SBATCH --gres=gpu:4
 
 #! How much wallclock time will be required?
-#SBATCH --time=02:00:00
+#SBATCH --time=04:00:00
 #! What types of email messages do you wish to receive?
 #SBATCH --mail-type=NONE
 #! Uncomment this to prevent the job from being requeued (e.g. if

--- a/train.py
+++ b/train.py
@@ -282,6 +282,7 @@ def main(cfg: BabyLMConfig):
     trainer.evaluate(
         metric_key_prefix="eval_best"
     )  # Note that this will also save the best model in the main output directory
+    collect_results(os.path.join(trainer.args.output_dir, "lm_model"))
 
     trainer.save_model(
         output_dir=os.path.join(training_args.output_dir, "best_model")


### PR DESCRIPTION
Just a little PR to update the way the evaluator script works to match what we're now doing at the end of training. This will let us run the evaluator on our previous baselines without having to do training again.